### PR TITLE
Load event list

### DIFF
--- a/CalendarWrapper.podspec
+++ b/CalendarWrapper.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'CalendarWrapper'
-  s.version          = '0.5.18'
+  s.version          = '0.5.19'
   s.summary          = 'Simple wrapper around the Google AppAuth and calendar API.'
 
 # This description is used to generate tags and improve search results.

--- a/CalendarWrapper.podspec
+++ b/CalendarWrapper.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'CalendarWrapper'
-  s.version          = '0.5.19'
+  s.version          = '0.5.20'
   s.summary          = 'Simple wrapper around the Google AppAuth and calendar API.'
 
 # This description is used to generate tags and improve search results.

--- a/CalendarWrapper.podspec
+++ b/CalendarWrapper.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'CalendarWrapper'
-  s.version          = '0.5.16'
+  s.version          = '0.5.18'
   s.summary          = 'Simple wrapper around the Google AppAuth and calendar API.'
 
 # This description is used to generate tags and improve search results.

--- a/CalendarWrapper/Classes/GCWCalendar.h
+++ b/CalendarWrapper/Classes/GCWCalendar.h
@@ -55,7 +55,8 @@
 
 - (void)loadEventsListFrom:(NSDate *_Nonnull)startDate
                         to:(NSDate *_Nonnull)endDate
-                   success:(void (^_Nullable)(NSDictionary *_Nonnull, NSArray *_Nonnull))success
+                    filter:(NSString *_Nullable)filter
+                   success:(void (^_Nullable)(NSDictionary *_Nonnull, NSArray *_Nonnull, NSUInteger))success
                    failure:(void (^_Nullable)(NSError *_Nonnull))failure;
 
 - (NSArray *_Nonnull)getFetchedEventsBefore:(NSDate *_Nonnull)startDate andAfter:(NSDate *_Nonnull)endDate;

--- a/CalendarWrapper/Classes/GCWCalendar.h
+++ b/CalendarWrapper/Classes/GCWCalendar.h
@@ -16,6 +16,7 @@
 @property (nonatomic, strong, nullable) id<CalendarAuthorizationProtocol> authorizationManager;
 @property (nonatomic) NSDictionary * _Nullable calendarEntries;
 @property (nonatomic) NSMutableDictionary * _Nullable calendarEvents;
+@property (nonatomic) NSMutableDictionary * _Nullable calendarSyncTokens;
 @property (nonatomic) NSDictionary * _Nullable userAccounts;
 @property (nonatomic, readonly) NSDictionary * _Nullable accountEntries;
 @property (nonatomic) NSNumber *_Nonnull notificationPeriod;
@@ -52,12 +53,10 @@
                      success:(void (^_Nullable)(GCWCalendarEvent *_Nonnull))success
                      failure:(void (^_Nullable)(NSError *_Nonnull))failure;
 
-- (void)loadEventsListForCalendar:(NSString *_Nonnull)calendarId
-                        startDate:(NSDate *_Nonnull)startDate
-                          endDate:(NSDate *_Nonnull)endDate
-                       maxResults:(NSUInteger)maxResults
-                          success:(void (^_Nullable)(NSDictionary *_Nonnull))success
-                          failure:(void (^_Nullable)(NSError *_Nonnull))failure;
+- (void)loadEventsListFrom:(NSDate *_Nonnull)startDate
+                        to:(NSDate *_Nonnull)endDate
+                   success:(void (^_Nullable)(NSDictionary *_Nonnull, NSArray *_Nonnull))success
+                   failure:(void (^_Nullable)(NSError *_Nonnull))failure;
 
 - (void)syncEventsFrom:(NSDate *_Nonnull)startDate
                     to:(NSDate *_Nonnull)endDate

--- a/CalendarWrapper/Classes/GCWCalendar.h
+++ b/CalendarWrapper/Classes/GCWCalendar.h
@@ -58,7 +58,7 @@
                    success:(void (^_Nullable)(NSDictionary *_Nonnull, NSArray *_Nonnull))success
                    failure:(void (^_Nullable)(NSError *_Nonnull))failure;
 
-- (NSArray *)getFetchedEventsBefore:(NSDate *_Nonnull)startDate andAfter:(NSDate *_Nonnull)endDate;
+- (NSArray *_Nonnull)getFetchedEventsBefore:(NSDate *_Nonnull)startDate andAfter:(NSDate *_Nonnull)endDate;
 
 - (void)syncEventsFrom:(NSDate *_Nonnull)startDate
                     to:(NSDate *_Nonnull)endDate

--- a/CalendarWrapper/Classes/GCWCalendar.h
+++ b/CalendarWrapper/Classes/GCWCalendar.h
@@ -58,6 +58,8 @@
                    success:(void (^_Nullable)(NSDictionary *_Nonnull, NSArray *_Nonnull))success
                    failure:(void (^_Nullable)(NSError *_Nonnull))failure;
 
+- (NSArray *)getFetchedEventsBefore:(NSDate *_Nonnull)startDate andAfter:(NSDate *_Nonnull)endDate;
+
 - (void)syncEventsFrom:(NSDate *_Nonnull)startDate
                     to:(NSDate *_Nonnull)endDate
                success:(void (^_Nullable)(NSDictionary *_Nonnull, NSArray *_Nonnull))success

--- a/CalendarWrapper/Classes/GCWCalendar.h
+++ b/CalendarWrapper/Classes/GCWCalendar.h
@@ -6,6 +6,7 @@
 @class GTLRCalendarService;
 @class GCWCalendarEvent;
 @class GCWCalendarAuthorization;
+@class GCWLoadEventsListRequest;
 
 @protocol CalendarAuthorizationProtocol;
 
@@ -58,6 +59,8 @@
                     filter:(NSString *_Nullable)filter
                    success:(void (^_Nullable)(NSDictionary *_Nonnull, NSArray *_Nonnull, NSUInteger))success
                    failure:(void (^_Nullable)(NSError *_Nonnull))failure;
+
+- (GCWLoadEventsListRequest *_Nullable)createEventsListRequest;
 
 - (NSArray *_Nonnull)getFetchedEventsBefore:(NSDate *_Nonnull)startDate andAfter:(NSDate *_Nonnull)endDate;
 

--- a/CalendarWrapper/Classes/GCWCalendar.m
+++ b/CalendarWrapper/Classes/GCWCalendar.m
@@ -460,9 +460,11 @@ static NSString *const kCalendarEventsNotificationPeriodKey = @"calendarWrapperC
 
 - (void)loadEventsListFrom:(NSDate *)startDate
                         to:(NSDate *)endDate
-                   success:(void (^)(NSDictionary *, NSArray *))success
+                    filter:(NSString *)filter
+                   success:(void (^)(NSDictionary *, NSArray *, NSUInteger))success
                    failure:(void (^)(NSError *))failure {
 
+    __block NSUInteger filteredEventsCount = 0;
     NSMutableDictionary *removedEvents = [NSMutableDictionary dictionary];
     NSMutableDictionary *loadedEvents = [NSMutableDictionary dictionary];
     __block NSUInteger calendarIndex = 0;
@@ -490,6 +492,9 @@ static NSString *const kCalendarEventsNotificationPeriodKey = @"calendarWrapperC
                     GCWCalendarEvent *event = [[GCWCalendarEvent alloc] initWithGTLCalendarEvent:obj];
                     event.calendarId = calendar.identifier;
 
+                    if (filter.length && [event.JSONString.lowercaseString containsString:filter.lowercaseString]) {
+                        filteredEventsCount++;
+                    }
                     if ([event.status isEqualToString:@"cancelled"]) {
                         [self.calendarEvents removeObjectForKey:event.identifier];
                         removedEvents[event.identifier] = event;
@@ -532,7 +537,7 @@ static NSString *const kCalendarEventsNotificationPeriodKey = @"calendarWrapperC
                     }
                 }];
                 if (calendarIndex == self.calendarEntries.count-1) {
-                    success(loadedEvents, removedEvents.allValues);
+                    success(loadedEvents, removedEvents.allValues, filteredEventsCount);
                 }
                 calendarIndex++;
             }

--- a/CalendarWrapper/Classes/GCWCalendar.m
+++ b/CalendarWrapper/Classes/GCWCalendar.m
@@ -491,7 +491,6 @@ static NSString *const kCalendarEventsNotificationPeriodKey = @"calendarWrapperC
                 [list.items enumerateObjectsUsingBlock:^(GTLRCalendar_Event * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
                     GCWCalendarEvent *event = [[GCWCalendarEvent alloc] initWithGTLCalendarEvent:obj];
                     event.calendarId = calendar.identifier;
-
                     if (filter.length && [event.JSONString.lowercaseString containsString:filter.lowercaseString]) {
                         filteredEventsCount++;
                     }

--- a/CalendarWrapper/Classes/GCWCalendar.m
+++ b/CalendarWrapper/Classes/GCWCalendar.m
@@ -171,7 +171,7 @@ static NSString *const kCalendarEventsNotificationPeriodKey = @"calendarWrapperC
     [authorizations enumerateObjectsUsingBlock:^(GCWCalendarAuthorization * _Nonnull authorization, NSUInteger idx, BOOL * _Nonnull stop) {
         __block BOOL found = NO;
         [userIDs enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-            NSString *userID = (GCWCalendarAuthorization *)obj;
+            NSString *userID = (NSString *)obj;
             if ([userID isEqualToString:authorization.userID]) {
                 found = YES;
                 *stop = YES;
@@ -500,7 +500,7 @@ static NSString *const kCalendarEventsNotificationPeriodKey = @"calendarWrapperC
                         removedEvents[event.identifier] = event;
                     } else if (([event.startDate isLaterThanOrEqualTo:startDate] &&
                                 [event.endDate isEarlierThanOrEqualTo:endDate]) ||
-                               abs([event.startDate numberOfDaysUntil:event.endDate]) == 1) {
+                               labs([event.startDate numberOfDaysUntil:event.endDate]) == 1) {
                         event.color = [UIColor colorWithHex:calendar.backgroundColor];
 
                         id item = self.calendarEvents[event.identifier];
@@ -554,7 +554,7 @@ static NSString *const kCalendarEventsNotificationPeriodKey = @"calendarWrapperC
                 GCWCalendarEvent *event = [[GCWCalendarEvent alloc] initWithGTLCalendarEvent:obj];
                 if (([event.startDate isEarlierThan:startDate] ||
                      [event.endDate isLaterThan:endDate]) &&
-                    abs([event.startDate numberOfDaysUntil:event.endDate]) <= 1) {
+                    labs([event.startDate numberOfDaysUntil:event.endDate]) <= 1) {
                     [events addObject:event.identifier];
                 }
             }];
@@ -562,7 +562,7 @@ static NSString *const kCalendarEventsNotificationPeriodKey = @"calendarWrapperC
             GCWCalendarEvent *event = [[GCWCalendarEvent alloc] initWithGTLCalendarEvent:obj];
             if (([event.startDate isEarlierThan:startDate] ||
                  [event.endDate isLaterThan:endDate]) &&
-                abs([event.startDate numberOfDaysUntil:event.endDate]) <= 1) {
+                labs([event.startDate numberOfDaysUntil:event.endDate]) <= 1) {
                 [events addObject:event.identifier];
             }
         }
@@ -609,7 +609,7 @@ static NSString *const kCalendarEventsNotificationPeriodKey = @"calendarWrapperC
                         removedEvents[event.identifier] = event;
                     } else if (([event.startDate isLaterThanOrEqualTo:startDate] &&
                                 [event.endDate isEarlierThanOrEqualTo:endDate]) ||
-                               abs([event.startDate numberOfDaysUntil:event.endDate]) > 1) {
+                               labs([event.startDate numberOfDaysUntil:event.endDate]) > 1) {
                         event.color = [UIColor colorWithHex:calendar.backgroundColor];
 
                         id item = self.calendarEvents[event.identifier];

--- a/CalendarWrapper/Classes/GCWCalendarService.h
+++ b/CalendarWrapper/Classes/GCWCalendarService.h
@@ -122,9 +122,7 @@
 
 - (void)clearEventsCache;
 
-- (void)clearFetchedEventsBefore:(NSDate *_Nonnull)startDate
-                           after:(NSDate *_Nonnull)endDate
-                       completed:(void (^_Nonnull)(void))completed;
+- (void)clearFetchedEventsBefore:(NSDate *_Nonnull)startDate after:(NSDate *_Nonnull)endDate;
 
 @end
 

--- a/CalendarWrapper/Classes/GCWCalendarService.h
+++ b/CalendarWrapper/Classes/GCWCalendarService.h
@@ -100,6 +100,7 @@
 
 - (void)loadEventsListFrom:(NSDate *_Nonnull)startDate
                         to:(NSDate *_Nonnull)endDate
+                    filter:(NSString *_Nullable)filter
                    success:(void (^_Nullable)(NSUInteger))success
                    failure:(void (^_Nullable)(NSError *_Nonnull))failure;
 

--- a/CalendarWrapper/Classes/GCWCalendarService.h
+++ b/CalendarWrapper/Classes/GCWCalendarService.h
@@ -121,6 +121,10 @@
 
 - (void)clearEventsCache;
 
+- (void)clearFetchedEventsBefore:(NSDate *_Nonnull)startDate
+                           after:(NSDate *_Nonnull)endDate
+                       completed:(void (^_Nonnull)(void))completed;
+
 @end
 
 

--- a/CalendarWrapper/Classes/GCWCalendarService.h
+++ b/CalendarWrapper/Classes/GCWCalendarService.h
@@ -100,7 +100,7 @@
 
 - (void)loadEventsListFrom:(NSDate *_Nonnull)startDate
                         to:(NSDate *_Nonnull)endDate
-                   success:(void (^_Nullable)(BOOL))success
+                   success:(void (^_Nullable)(NSUInteger))success
                    failure:(void (^_Nullable)(NSError *_Nonnull))failure;
 
 - (void)syncEventsFrom:(NSDate *_Nonnull)startDate

--- a/CalendarWrapper/Classes/GCWCalendarService.h
+++ b/CalendarWrapper/Classes/GCWCalendarService.h
@@ -3,6 +3,7 @@
 @class GCWCalendar;
 @class GTLRCalendar_Event;
 @class GCWCalendarEvent;
+@class GCWLoadEventsListRequest;
 
 @protocol CalendarServiceDelegate <NSObject>
 
@@ -103,6 +104,8 @@
                     filter:(NSString *_Nullable)filter
                    success:(void (^_Nullable)(NSUInteger))success
                    failure:(void (^_Nullable)(NSError *_Nonnull))failure;
+
+- (GCWLoadEventsListRequest *_Nullable)createEventsListRequest;
 
 - (void)syncEventsFrom:(NSDate *_Nonnull)startDate
                     to:(NSDate *_Nonnull)endDate

--- a/CalendarWrapper/Classes/GCWCalendarService.h
+++ b/CalendarWrapper/Classes/GCWCalendarService.h
@@ -98,10 +98,15 @@
                   success:(void (^_Nonnull)(void))success
                   failure:(void (^_Nonnull)(NSError *_Nonnull))failure;
 
-- (void)loadEventsOnSuccess:(void (^_Nonnull)(NSArray <GCWCalendarEvent *> *_Nullable events, NSDictionary *_Nullable calendarList))success
-                    failure:(void (^_Nonnull)(NSError *_Nonnull))failure;
+- (void)loadEventsListFrom:(NSDate *_Nonnull)startDate
+                        to:(NSDate *_Nonnull)endDate
+                   success:(void (^_Nullable)(BOOL))success
+                   failure:(void (^_Nullable)(NSError *_Nonnull))failure;
 
-- (void)syncEventsOnSuccess:(void (^_Nonnull)(BOOL))success failure:(void (^_Nonnull)(NSError *_Nonnull))failure;
+- (void)syncEventsFrom:(NSDate *_Nonnull)startDate
+                    to:(NSDate *_Nonnull)endDate
+               success:(void (^_Nonnull)(BOOL))success
+               failure:(void (^_Nonnull)(NSError *_Nonnull))failure;
 
 - (void)loadEventForCalendar:(NSString *_Nonnull)calendarId
                      eventId:(NSString *_Nonnull)eventId
@@ -113,6 +118,8 @@
                        failure:(void (^_Nonnull)(NSError *_Nonnull))failure;
 
 - (void)saveState;
+
+- (void)clearEventsCache;
 
 @end
 

--- a/CalendarWrapper/Classes/GCWCalendarService.m
+++ b/CalendarWrapper/Classes/GCWCalendarService.m
@@ -444,15 +444,12 @@ static NSString * const kCalendarFilterKey = @"calendarWrapperCalendarFilterKey"
     [self.calendar.calendarSyncTokens removeAllObjects];
 }
 
-- (void)clearFetchedEventsBefore:(NSDate *)startDate
-                           after:(NSDate *)endDate
-                       completed:(void (^)(void))completed {
+- (void)clearFetchedEventsBefore:(NSDate *)startDate after:(NSDate *)endDate {
     NSArray *events = [self.calendar getFetchedEventsBefore:startDate andAfter:endDate];
     [events enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         NSString *eventId = (NSString *)obj;
-        [self removeEventFromCache:eventId];
+        [self.calendar.calendarEvents removeObjectForKey:eventId];
     }];
-    completed();
 }
 
 #pragma mark - Private

--- a/CalendarWrapper/Classes/GCWCalendarService.m
+++ b/CalendarWrapper/Classes/GCWCalendarService.m
@@ -440,6 +440,17 @@ static NSString * const kCalendarFilterKey = @"calendarWrapperCalendarFilterKey"
     [self.calendar.calendarSyncTokens removeAllObjects];
 }
 
+- (void)clearFetchedEventsBefore:(NSDate *)startDate
+                           after:(NSDate *)endDate
+                       completed:(void (^)(void))completed {
+    NSArray *events = [self.calendar getFetchedEventsBefore:startDate andAfter:endDate];
+    [events enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        NSString *eventId = (NSString *)obj;
+        [self removeEventFromCache:eventId];
+    }];
+    completed();
+}
+
 #pragma mark - Private
 
 - (void)removeEventFromCache:(NSString *)eventId {

--- a/CalendarWrapper/Classes/GCWCalendarService.m
+++ b/CalendarWrapper/Classes/GCWCalendarService.m
@@ -133,13 +133,13 @@ static NSString * const kCalendarFilterKey = @"calendarWrapperCalendarFilterKey"
 
 - (void)loadEventsListFrom:(NSDate *)startDate
                         to:(NSDate *)endDate
-                   success:(void (^)(BOOL))success
+                   success:(void (^)(NSUInteger))success
                    failure:(void (^)(NSError * _Nonnull))failure {
     
     __weak GCWCalendarService *weakSelf = self;
     [self.calendar loadEventsListFrom:startDate to:endDate
                               success:^(NSDictionary *loadedEvents, NSArray *removedEvents) {
-        success(loadedEvents.count > 0 || removedEvents.count > 0);
+        success(loadedEvents.count + removedEvents.count);
     } failure:^(NSError *error) {
         failure(error);
     }];

--- a/CalendarWrapper/Classes/GCWCalendarService.m
+++ b/CalendarWrapper/Classes/GCWCalendarService.m
@@ -7,10 +7,9 @@
 #import "NSDate+GCWDate.h"
 #import "UIColor+MNTColor.h"
 
+
 static NSString * const kClientID = @"350629588452-bcbi20qrl4tsvmtia4ps4q16d8i9sc4l.apps.googleusercontent.com";
 static NSString * const kCalendarFilterKey = @"calendarWrapperCalendarFilterKey";
-static NSUInteger daysInPast = -15;
-static NSUInteger daysInFuture = 45;
 
 @interface GCWCalendarService () <CalendarServiceProtocol>
 
@@ -132,9 +131,24 @@ static NSUInteger daysInFuture = 45;
     }];
 }
 
-- (void)syncEventsOnSuccess:(void (^)(BOOL))success failure:(void (^)(NSError *))failure {
-    NSDate *startDate = [NSDate dateFromNumberOfDaysSinceNow:daysInPast];
-    NSDate *endDate = [NSDate dateFromNumberOfDaysSinceNow:daysInFuture];
+- (void)loadEventsListFrom:(NSDate *)startDate
+                        to:(NSDate *)endDate
+                   success:(void (^)(BOOL))success
+                   failure:(void (^)(NSError * _Nonnull))failure {
+    
+    __weak GCWCalendarService *weakSelf = self;
+    [self.calendar loadEventsListFrom:startDate to:endDate
+                              success:^(NSDictionary *loadedEvents, NSArray *removedEvents) {
+        success(loadedEvents.count > 0 || removedEvents.count > 0);
+    } failure:^(NSError *error) {
+        failure(error);
+    }];
+}
+
+- (void)syncEventsFrom:(NSDate *)startDate
+                    to:(NSDate *)endDate
+               success:(void (^)(BOOL))success
+               failure:(void (^)(NSError *))failure {
 
     __weak GCWCalendarService *weakSelf = self;
     [self.calendar syncEventsFrom:startDate to:endDate success:^(NSDictionary *syncedEvents, NSArray *removedEvents) {
@@ -419,6 +433,11 @@ static NSUInteger daysInFuture = 45;
 
 - (void)saveState {
     [self.calendar saveState];
+}
+
+- (void)clearEventsCache {
+    [self.calendar.calendarEvents removeAllObjects];
+    [self.calendar.calendarSyncTokens removeAllObjects];
 }
 
 #pragma mark - Private

--- a/CalendarWrapper/Classes/GCWCalendarService.m
+++ b/CalendarWrapper/Classes/GCWCalendarService.m
@@ -133,13 +133,18 @@ static NSString * const kCalendarFilterKey = @"calendarWrapperCalendarFilterKey"
 
 - (void)loadEventsListFrom:(NSDate *)startDate
                         to:(NSDate *)endDate
+                    filter:(NSString *)filter
                    success:(void (^)(NSUInteger))success
                    failure:(void (^)(NSError * _Nonnull))failure {
     
     __weak GCWCalendarService *weakSelf = self;
-    [self.calendar loadEventsListFrom:startDate to:endDate
-                              success:^(NSDictionary *loadedEvents, NSArray *removedEvents) {
-        success(loadedEvents.count + removedEvents.count);
+    [self.calendar loadEventsListFrom:startDate to:endDate filter:filter
+                              success:^(NSDictionary *loadedEvents, NSArray *removedEvents, NSUInteger filteredEventsCount) {
+        if (filter.length) {
+            success(filteredEventsCount);
+        } else {
+            success(loadedEvents.count + removedEvents.count);
+        }
     } failure:^(NSError *error) {
         failure(error);
     }];
@@ -461,7 +466,6 @@ static NSString * const kCalendarFilterKey = @"calendarWrapperCalendarFilterKey"
 - (void)removeRecurringEvent:(NSString *)recurringEventId {
     NSPredicate *predicate = [NSPredicate predicateWithFormat:@"recurringEventId == %@", recurringEventId];
     NSArray *filteredArray = [self.calendar.calendarEvents.allValues filteredArrayUsingPredicate:predicate];
-
     if (filteredArray.count) {
         for (GCWCalendarEvent *event in filteredArray) {
             [self.calendar.calendarEvents removeObjectForKey:event.identifier];

--- a/CalendarWrapper/Classes/GCWCalendarService.m
+++ b/CalendarWrapper/Classes/GCWCalendarService.m
@@ -137,7 +137,6 @@ static NSString * const kCalendarFilterKey = @"calendarWrapperCalendarFilterKey"
                    success:(void (^)(NSUInteger))success
                    failure:(void (^)(NSError * _Nonnull))failure {
     
-    __weak GCWCalendarService *weakSelf = self;
     [self.calendar loadEventsListFrom:startDate to:endDate filter:filter
                               success:^(NSDictionary *loadedEvents, NSArray *removedEvents, NSUInteger filteredEventsCount) {
         if (filter.length) {

--- a/CalendarWrapper/Classes/GCWCalendarService.m
+++ b/CalendarWrapper/Classes/GCWCalendarService.m
@@ -1,6 +1,8 @@
 #import "GCWCalendarService.h"
 #import "GCWCalendarEntry.h"
 #import "GCWCalendarEvent.h"
+#import "GCWLoadEventsListRequest.h"
+
 #import "NSDictionary+GCWCalendarEvent.h"
 #import "NSArray+GCWEventsSorting.h"
 #import "NSDictionary+GCWCalendar.h"
@@ -147,6 +149,10 @@ static NSString * const kCalendarFilterKey = @"calendarWrapperCalendarFilterKey"
     } failure:^(NSError *error) {
         failure(error);
     }];
+}
+
+- (GCWLoadEventsListRequest *)createEventsListRequest {
+    return [self.calendar createEventsListRequest];
 }
 
 - (void)syncEventsFrom:(NSDate *)startDate

--- a/CalendarWrapper/Classes/GCWLoadEventsListRequest.h
+++ b/CalendarWrapper/Classes/GCWLoadEventsListRequest.h
@@ -1,0 +1,23 @@
+#import <UIKit/UIKit.h>
+
+@protocol CalendarAuthorizationProtocol;
+
+@interface GCWLoadEventsListRequest : NSObject
+
+@property (nonatomic, strong, nonnull, readonly) id<CalendarAuthorizationProtocol> authorizationManager;
+@property (nonatomic, nonnull, readonly) NSDictionary *calendarUsers;
+@property (nonatomic, nonnull, readonly) NSDictionary *calendarEntries;
+
+- (instancetype _Nullable)initWithCalendarEntries:(NSDictionary *_Nonnull)calendarEntries
+                             authorizationManager:(id<CalendarAuthorizationProtocol> _Nonnull)authorizationManager
+                                    calendarUsers:(NSDictionary *_Nonnull)calendarUsers;
+
+- (void)startFrom:(NSDate *_Nonnull)startDate
+          endDate:(NSDate *_Nonnull)endDate
+           filter:(NSString *_Nonnull)filter
+          success:(void (^_Nullable)(NSArray *_Nonnull))success
+          failure:(void (^_Nullable)(NSError *_Nonnull))failure;
+
+- (void)cancel;
+
+@end

--- a/CalendarWrapper/Classes/GCWLoadEventsListRequest.m
+++ b/CalendarWrapper/Classes/GCWLoadEventsListRequest.m
@@ -1,0 +1,121 @@
+#import "GCWLoadEventsListRequest.h"
+
+#import "GCWCalendar.h"
+#import "GCWCalendarEntry.h"
+#import "GCWCalendarEvent.h"
+#import "GCWCalendarAuthorizationManager.h"
+#import "GCWCalendarAuthorization.h"
+
+#import "UIColor+MNTColor.h"
+
+@interface GCWLoadEventsListRequest ()
+
+@property (nonatomic) NSMutableArray *calendarServiceTickets;
+@property (nonatomic) NSMutableDictionary *events;
+@property (nonatomic) BOOL cancelled;
+
+@end
+
+@implementation GCWLoadEventsListRequest
+
++ (NSError *)createErrorWithCode:(NSInteger)code description:(NSString *)description {
+    NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:description, NSLocalizedDescriptionKey, nil];
+    return [NSError errorWithDomain:@"com.calendar-wrapper" code:code userInfo:userInfo];
+}
+
+- (instancetype)initWithCalendarEntries:(NSDictionary *)calendarEntries
+                   authorizationManager:(id<CalendarAuthorizationProtocol>)authorizationManager
+                          calendarUsers:(NSDictionary *)calendarUsers {
+    self = [super init];
+    if (self) {
+        _authorizationManager = authorizationManager;
+        _calendarUsers = calendarUsers;
+        _calendarEntries = calendarEntries;
+
+        _calendarServiceTickets = [NSMutableArray array];
+        _events = [NSMutableDictionary dictionary];
+    }
+    return self;
+}
+
+- (GCWCalendarAuthorization *)getAuthorizationForCalendar:(NSString *)calendarId {
+    __block GCWCalendarAuthorization *calendarAuthorization = nil;
+    NSString *userId = self.calendarUsers[calendarId];
+    NSArray *authorizations = [self.authorizationManager getAuthorizations];
+    [authorizations enumerateObjectsUsingBlock:^(GCWCalendarAuthorization * _Nonnull authorization, NSUInteger idx, BOOL * _Nonnull stop) {
+        if ([authorization.userID isEqualToString:userId]) {
+            calendarAuthorization = authorization;
+            *stop = YES;
+        }
+    }];
+    return calendarAuthorization;
+}
+
+- (void)startFrom:(NSDate *)startDate
+          endDate:(NSDate *)endDate
+           filter:(NSString *)filter
+          success:(void (^)(NSArray *))success failure:(void (^)(NSError *))failure {
+    
+    GTLRCalendarService *calendarService = [[GTLRCalendarService alloc] init];
+    calendarService.shouldFetchNextPages = YES;
+    calendarService.retryEnabled = YES;
+
+    __block NSUInteger calendarIndex = 0;
+    for (GCWCalendarEntry *calendar in self.calendarEntries.allValues) {
+        GCWCalendarAuthorization *authorization = [self getAuthorizationForCalendar:calendar.identifier];
+        if (!authorization) {
+            failure([GCWLoadEventsListRequest createErrorWithCode:-10002
+                                                      description:[NSString stringWithFormat: @"Missing authorization for calendar %@", calendar.identifier]]);
+            return;
+        }
+        calendarService.authorizer = authorization.fetcherAuthorization;
+        calendarService.shouldFetchNextPages = YES;
+
+        GTLRCalendarQuery_EventsList *query = [GTLRCalendarQuery_EventsList queryWithCalendarId:calendar.identifier];
+        query.timeMin = [GTLRDateTime dateTimeWithDate:startDate];
+        query.timeMax = [GTLRDateTime dateTimeWithDate:endDate];
+        query.singleEvents = YES;
+        query.maxResults = 2500;
+        query.orderBy = kGTLRCalendarOrderByStartTime;
+        GTLRServiceTicket *ticket = [calendarService executeQuery:query completionHandler:^(GTLRServiceTicket * _Nonnull callbackTicket, id  _Nullable object, NSError * _Nullable callbackError) {
+            if (callbackError) {
+                failure(callbackError);
+            } else {
+                if (self.cancelled) {
+                    return;
+                }
+                GTLRCalendar_Events *list = object;
+                [list.items enumerateObjectsUsingBlock:^(GTLRCalendar_Event * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+                    GCWCalendarEvent *event = [[GCWCalendarEvent alloc] initWithGTLCalendarEvent:obj];
+                    event.calendarId = calendar.identifier;
+                    if (![event.status isEqualToString:@"cancelled"] &&
+                        [event.JSONString.lowercaseString containsString:filter.lowercaseString]) {
+                        event.color = [UIColor colorWithHex:calendar.backgroundColor];
+                        self.events[event.identifier] = event;
+                    }
+                }];
+                if (calendarIndex == self.calendarEntries.count-1) {
+                    [self.calendarServiceTickets removeAllObjects];
+                    success([self.events.allValues copy]);
+                }
+                calendarIndex++;
+            }
+        }];
+        [self.calendarServiceTickets addObject:ticket];
+    }
+}
+
+- (void)cancel {
+    self.cancelled = YES;
+
+    [self.calendarServiceTickets enumerateObjectsUsingBlock:^(id  _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        GTLRServiceTicket *ticket = (GTLRServiceTicket *)obj;
+        [ticket cancelTicket];
+    }];
+    [self.calendarServiceTickets removeAllObjects];
+    [self.events removeAllObjects];
+
+    self.cancelled = NO;
+}
+
+@end

--- a/CalendarWrapper/Classes/NSDate+GCWDate.h
+++ b/CalendarWrapper/Classes/NSDate+GCWDate.h
@@ -13,12 +13,12 @@ typedef NS_ENUM(NSInteger, GCWCalendarDayType) {
 @property (nonatomic, readonly) GCWCalendarDayType dayType;
 @property (nonatomic, readonly) BOOL isInCurrentYear;
 
-+ (NSDate *)dateFromNumberOfMonthSinceNow:(NSInteger)month;
-+ (NSDate *)dateFromNumberOfDaysSinceNow:(NSInteger)days;
-
 - (BOOL)inSameDayAsDate:(NSDate *)date;
-- (NSDate *)dateFromNumberOfMonth:(NSInteger)month;
-- (NSDate *)dateFromNumberOfDays:(NSInteger)days;
+- (BOOL) isLaterThanOrEqualTo:(NSDate*)date;
+- (BOOL) isEarlierThanOrEqualTo:(NSDate*)date;
+- (BOOL) isLaterThan:(NSDate*)date;
+- (BOOL) isEarlierThan:(NSDate*)date;
+
 - (NSDate *)dateFromNumberOfHours:(NSInteger)hours;
 - (NSDate *)dateFromNumberOfSeconds:(NSInteger)seconds;
 - (NSDate *)dateWithDaylightSavingOffset;

--- a/CalendarWrapper/Classes/NSDate+GCWDate.m
+++ b/CalendarWrapper/Classes/NSDate+GCWDate.m
@@ -4,20 +4,6 @@
 
 @implementation NSDate (GCWDate)
 
-+ (NSDate *)dateFromNumberOfMonthSinceNow:(NSInteger)month {
-    NSCalendar *calendar = [NSCalendar currentCalendar];
-    NSDateComponents *dateComponents = [NSDateComponents new];
-    dateComponents.month = month;
-    return [calendar dateByAddingComponents:dateComponents toDate:[NSDate date] options:NSCalendarMatchStrictly];
-}
-
-+ (NSDate *)dateFromNumberOfDaysSinceNow:(NSInteger)days {
-    return [NSCalendar.currentCalendar dateByAddingUnit:NSCalendarUnitDay
-                                                  value:days
-                                                 toDate:[NSDate date]
-                                                options:0];
-}
-
 - (NSDate *)dateWithDaylightSavingOffset {
     BOOL isDaylightSaving = [NSTimeZone.localTimeZone isDaylightSavingTimeForDate:self];
 
@@ -27,20 +13,6 @@
     } else {
         return self;
     }
-}
-
-- (NSDate *)dateFromNumberOfMonth:(NSInteger)month {
-    NSCalendar *calendar = [NSCalendar currentCalendar];
-    NSDateComponents *dateComponents = [NSDateComponents new];
-    dateComponents.month = month;
-    return [calendar dateByAddingComponents:dateComponents toDate:self options:NSCalendarMatchStrictly];
-}
-
-- (NSDate *)dateFromNumberOfDays:(NSInteger)days {
-    return [NSCalendar.currentCalendar dateByAddingUnit:NSCalendarUnitDay
-                                                  value:days
-                                                 toDate:self
-                                                options:0];
 }
 
 - (NSDate *)dateFromNumberOfHours:(NSInteger)hours {
@@ -85,6 +57,23 @@
 
 - (BOOL)inSameDayAsDate:(NSDate *)date {
     return date ? [[NSCalendar currentCalendar] isDate:self inSameDayAsDate:date] : NO;
+}
+
+-(BOOL) isLaterThanOrEqualTo:(NSDate*)date {
+    return !([self compare:date] == NSOrderedAscending);
+}
+
+-(BOOL) isEarlierThanOrEqualTo:(NSDate*)date {
+    return !([self compare:date] == NSOrderedDescending);
+}
+
+-(BOOL) isLaterThan:(NSDate*)date {
+    return ([self compare:date] == NSOrderedDescending);
+
+}
+
+-(BOOL) isEarlierThan:(NSDate*)date {
+    return ([self compare:date] == NSOrderedAscending);
 }
 
 - (NSInteger)numberOfDaysUntil:(NSDate *)date {

--- a/CalendarWrapper/Classes/NSDate+GCWDate.m
+++ b/CalendarWrapper/Classes/NSDate+GCWDate.m
@@ -77,10 +77,11 @@
 }
 
 - (NSInteger)numberOfDaysUntil:(NSDate *)date {
-    NSDateComponents *startComponents = [NSCalendar.currentCalendar components:NSCalendarUnitDay fromDate:self];
-    NSDateComponents *endComponents = [NSCalendar.currentCalendar components:NSCalendarUnitDay fromDate:date];
-
-    return endComponents.day - startComponents.day;
+    NSDateComponents *components = [NSCalendar.currentCalendar components:NSCalendarUnitDay
+                                                                 fromDate:self
+                                                                   toDate:date
+                                                                  options:0];
+    return components.day;
 }
 
 @end

--- a/Example/CalendarWrapper/GCWViewController.m
+++ b/Example/CalendarWrapper/GCWViewController.m
@@ -141,12 +141,11 @@ static NSString * _Nonnull const kClientID = @"350629588452-bcbi20qrl4tsvmtia4ps
 
 - (void)loadEvents {
     __weak GCWViewController *weakSelf = self;
-    [self.calendar loadEventsListForCalendar:self.defaultCalendarId
-                                   startDate:[NSDate date]
-                                     endDate:[NSDate dateWithTimeIntervalSinceNow:7 * 24 * 3600]
-                                  maxResults:0
-                                     success:^(NSDictionary *events) {
-        self.events = events;
+    [self.calendar loadEventsListFrom:[NSDate date]
+                                   to:[NSDate dateWithTimeIntervalSinceNow:7 * 24 * 3600]
+                               filter:nil
+                              success:^(NSDictionary *loadedEvents, NSArray *removedEvents, NSUInteger fetchedCound) {
+        self.events = loadedEvents;
         [weakSelf.eventsTable reloadData];
     } failure:^(NSError *error) {
         if (error.code == 1001) {

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - AppAuth/ExternalUserAgent (= 1.4.0)
   - AppAuth/Core (1.4.0)
   - AppAuth/ExternalUserAgent (1.4.0)
-  - CalendarWrapper (0.5.18):
+  - CalendarWrapper (0.5.19):
     - AppAuth
     - GoogleAPIClientForREST/Calendar (~> 1.3)
     - GTMAppAuth
@@ -57,7 +57,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
-  CalendarWrapper: 8e1f181297bf0526d83edc6aacf99860c989d0f8
+  CalendarWrapper: 47d81cac53262c81abf8a917e4fd8197440f7d06
   GoogleAPIClientForREST: 4bb409633efcc2e1b3f945afe7e35039b5a61db2
   GTMAppAuth: 197a8dabfea5d665224aa00d17f164fc2248dab9
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - AppAuth/ExternalUserAgent (= 1.4.0)
   - AppAuth/Core (1.4.0)
   - AppAuth/ExternalUserAgent (1.4.0)
-  - CalendarWrapper (0.5.16):
+  - CalendarWrapper (0.5.18):
     - AppAuth
     - GoogleAPIClientForREST/Calendar (~> 1.3)
     - GTMAppAuth
@@ -57,7 +57,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
-  CalendarWrapper: 11d34b439f6823879117a0182250f1ca0bc39c53
+  CalendarWrapper: 8e1f181297bf0526d83edc6aacf99860c989d0f8
   GoogleAPIClientForREST: 4bb409633efcc2e1b3f945afe7e35039b5a61db2
   GTMAppAuth: 197a8dabfea5d665224aa00d17f164fc2248dab9
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - AppAuth/ExternalUserAgent (= 1.4.0)
   - AppAuth/Core (1.4.0)
   - AppAuth/ExternalUserAgent (1.4.0)
-  - CalendarWrapper (0.5.19):
+  - CalendarWrapper (0.5.20):
     - AppAuth
     - GoogleAPIClientForREST/Calendar (~> 1.3)
     - GTMAppAuth
@@ -57,7 +57,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
-  CalendarWrapper: 47d81cac53262c81abf8a917e4fd8197440f7d06
+  CalendarWrapper: ada86f3fce361b20ba86335c844b00866ad78c2f
   GoogleAPIClientForREST: 4bb409633efcc2e1b3f945afe7e35039b5a61db2
   GTMAppAuth: 197a8dabfea5d665224aa00d17f164fc2248dab9
   GTMSessionFetcher: b3503b20a988c4e20cc189aa798fd18220133f52


### PR DESCRIPTION
- Implemented GCWLoadEventsListRequest and modified GCWCalendar and GCWCalendarService to use create instance.
- Fixed the 410 sync error handling so library will remove all the sync tokens and all the events.
- Added filter parameter to GCWCalendarService.loadEventsList and GCWCalendar.loadEventsList methods.
- Fixed bug causing invalid number of user ids to be persisted on local storage.
- Included all-day events in GCWCalendar.loadEventsList response.
- Modified GCWCalendarService.loadEventsList success block to return number of events in response.
- Fixed bug in NSDate+GCWDate.numberOfDays category method causing invalid number of days between different months/years.
- Implemented GCWCalendarService.clearFetchedEvents method.
- Modified loadEventList to load events from startDate to endDate.